### PR TITLE
Actually test vanillajs tests

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -467,7 +467,8 @@ def runTest(engine, testOptions, testName, testReport, testOut):
 		file = open(driverFile, "w")
 		compiledFileRead = open(testOptions.primaryFile, "r")
 		driverFileRead = open(testingFile, "r")
-		file.write(compiledFileRead.read() + "\n" + driverFileRead.read() + "\nvar EXPORTS = getExports();\ngetPromise(EXPORTS).then(_=>{onInstantiation(EXPORTS);});\n")
+		file.write(compiledFileRead.read() + "\n" + driverFileRead.read() + "\nvar EXPORTS = getExports();\ngetPromise(EXPORTS).then(_=>{onInstantiation(getExports());});\n")
+		file.close()
 
 	ret=subprocess.call(engine + [driverFile], stderr=testReport,
 		stdout=testOut);


### PR DESCRIPTION
Before, the file for vanillajs tests were not closed, making it test an empty file which always passes.

Closing the file also reveals that the driverfile for vanillajs doesn't properly work. The EXPORTS variable is initialized with old exports before they're initialized in WebAssembly.instantiate. This makes it so that the onInstantiation call gets exports that are mapped to the __dummy function.

I'm not a 100% sure about the vanillajs driverfile fix. So any feedback is welcome.