### PR TITLE
Add test for crash when using allocations in global initializers

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -151,6 +151,7 @@ common_tests = [
         'unit/types/padding1.cpp',
         'unit/types/padding2.cpp',
         'unit/types/padding3.cpp',
+        'unit/globals/initializers.cpp',
 		]
 genericjs_only_tests = [
 		'unit/dom/test1.cpp','unit/dom/test2.cpp','unit/dom/test3.cpp','unit/dom/test4.cpp',

--- a/tests/unit/globals/initializers.cpp
+++ b/tests/unit/globals/initializers.cpp
@@ -1,0 +1,15 @@
+//===---------------------------------------------------------------------===//
+//	Copyright 2022 Leaning Technologies
+//===----------------------------------------------------------------------===//
+#include <tests.h>
+#include <stdlib.h>
+
+int* p1 = (int*) malloc(900);
+int* p2 = (int*) calloc(1, 900);
+int* p3 = (int*) realloc((int*) 0, 900);
+
+int main() {
+	assertEqual(p1!=0, true, "expected p1 memory to be allocated");
+	assertEqual(p2!=0, true, "expected p2 memory to be allocated");
+	assertEqual(p3!=0, true, "expected p3 memory to be allocated");
+}


### PR DESCRIPTION
The accompanying tests for https://github.com/leaningtech/cheerp-compiler/pull/181