### PR TITLE
Add tests for atomics

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -227,6 +227,8 @@ addToTestListIfMatch(Test.genericjsOnly('unit/coroutines/test1.cpp', [['-std=c++
 addToTestListIfMatch(Test.common('unit/exceptions/test1.cpp', [['-fexceptions']]))
 addToTestListIfMatch(Test.common('unit/exceptions/test2.cpp', [['-fexceptions']]))
 addToTestListIfMatch(Test.common('unit/types/funccasts.cpp', [['-cheerp-fix-wrong-func-casts']]))
+addToTestListIfMatch(Test.common('unit/threading/atomic1.cpp', [['-pthread']]))
+addToTestListIfMatch(Test.linearOnly('unit/threading/atomic2.cpp', [['-pthread']]))
 
 selected_tests = sorted(list(test_list))
 
@@ -503,6 +505,8 @@ def runTest(engine, testOptions, testName, testReport, testOut):
             failure |= bool(match)
         for testLineErr in testReport:
             match = re.search("error|fail|invalid", testLineErr, re.IGNORECASE)
+            if (testOptions.allowSABwarning and match):
+                match = not re.search("Linking failure in asm.js: Invalid heap type: SharedArrayBuffer", testLineErr)
             failure |= bool(match)
     else:
         failure = True
@@ -527,6 +531,7 @@ class TestOptions:
         if (mode == "wasm"):
             self.secondaryFile = basePath + ".wasm"
         self.module = 'none'
+        self.allowSABwarning = False
         for f in extraFlags:
             if f == '-cheerp-make-module=es6':
                 self.module = 'es6'
@@ -534,6 +539,8 @@ class TestOptions:
                 self.module = 'closure'
             if f == '-cheerp-make-module=commonjs':
                 self.module = 'commonjs'
+            if f == '-pthread':
+                self.allowSABwarning = True
         self.primaryFile = basePath + ".js"
         if (self.module == 'es6'):
             self.primaryFile = basePath + ".mjs"

--- a/tests/unit/threading/atomic1.cpp
+++ b/tests/unit/threading/atomic1.cpp
@@ -1,0 +1,45 @@
+#include <tests.h>
+#include <atomic>
+
+struct structWithAtomicMember
+{
+	std::atomic<int> atomicValue;
+};
+
+struct normalStruct
+{
+	int value;
+};
+
+int main()
+{
+	std::atomic<int> val = 4205;
+	val.fetch_add(1391);
+	val.fetch_and(6234);
+	val.fetch_or(9196);
+	val.fetch_sub(4985);
+	val.fetch_xor(7578);
+	assertEqual(val.load(), 15641, "Atomic binary operations");
+
+	int b = 90;
+	b += val.exchange(3125);
+	b += val.fetch_add(7264);
+	b += val.fetch_sub(4981);
+	b += val.fetch_or(2037);
+	b += val.fetch_and(8185);
+	b += val.load();
+	assertEqual(b, 46915 , "Atomic binary return values");
+
+	structWithAtomicMember s1;
+	s1.atomicValue.store(3);
+	s1.atomicValue.fetch_add(95);
+	s1.atomicValue.fetch_and(51);
+	assertEqual(s1.atomicValue.load(), 34, "Atomic value inside struct");
+
+	normalStruct s2 = {3};
+	std::atomic<normalStruct> s3;
+	s3.store(s2);
+	s2.value = 25;
+	s2 = s3.load();
+	assertEqual(s2.value, 3, "Atomic struct");
+}

--- a/tests/unit/threading/atomic2.cpp
+++ b/tests/unit/threading/atomic2.cpp
@@ -1,0 +1,28 @@
+#include <tests.h>
+#include <atomic>
+
+struct Node
+{
+	int value;
+	Node* next;
+};
+std::atomic<Node*> listHead(nullptr);
+
+void appendToList(int newValue)
+{
+	Node* oldHead = listHead;
+	Node* newNode = new Node {newValue, oldHead};
+
+	while (!listHead.compare_exchange_strong(oldHead, newNode))
+		newNode->next = oldHead;
+}
+
+int main()
+{
+	for (int i = 0; i < 10; i++)
+		appendToList(i);
+
+	Node* it = listHead;
+	it = it->next->next->next;
+	assertEqual(it->value, 6, "Compare exchange list");
+}


### PR DESCRIPTION
Added two tests to test atomics. atomic2.cpp only runs for asmjs and wasm, is broken in genericjs for now. Node gives a warning when using a SharedArrayBuffer in asmjs, which is required for threading. This warning will be filtered out for tests that link with -pthread.