### PR TITLE
Restrict _Any casts to client or primitive types

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -233,6 +233,7 @@ addToTestListIfMatch(Test.common('unit/jsexport/member_variables.cpp', [[], ['-c
 addToTestListIfMatch(Test.common('unit/jsexport/empty_class.cpp', [[], ['-cheerp-make-module=closure'], ['-cheerp-make-module=commonjs'],['-cheerp-make-module=es6']]))
 addToTestListIfMatch(Test.common('unit/jsexport/inheritance.cpp', [[], ['-cheerp-make-module=closure'], ['-cheerp-make-module=commonjs'],['-cheerp-make-module=es6']]))
 addToTestListIfMatch(Test.genericjsOnly('unit/coroutines/test1.cpp', [['-std=c++20']]))
+addToTestListIfMatch(Test.genericjsOnly('unit/coroutines/cast-promise.cpp', [['-std=c++20']]))
 addToTestListIfMatch(Test.common('unit/exceptions/test1.cpp', [['-fexceptions']]))
 addToTestListIfMatch(Test.linearOnly('unit/exceptions/test2.cpp', [['-fexceptions']]))
 addToTestListIfMatch(Test.common('unit/types/funccasts.cpp', [['-cheerp-fix-wrong-func-casts']]))

--- a/tests/unit/coroutines/cast-promise.cpp
+++ b/tests/unit/coroutines/cast-promise.cpp
@@ -1,0 +1,27 @@
+//===---------------------------------------------------------------------===//
+//	Copyright 2024 Leaning Technlogies
+//===----------------------------------------------------------------------===//
+
+#include <coroutine>
+
+#include <cheerp/jsobject.h>
+
+struct Task {
+	struct promise_type {
+		// Ensure `promise_type` does not fit inside a register, so that we get an
+		// error if the conversion described below is selected.
+		char _[1024];
+
+		Task get_return_object();
+		std::suspend_never initial_suspend() const noexcept;
+		std::suspend_never final_suspend() const noexcept;
+		void return_void();
+	};
+};
+
+// Tries to construct `Task::promise_type` using the generic conversion
+// `operator T()` on `client::_Any`. The conversion should not be considered by
+// overload resolution because of SFINAE.
+Task foo(const client::Object&) {
+	co_return;
+}


### PR DESCRIPTION
Adds some SFINAE restrictions to `_Any` casts to prevent accidental invalid implicit casts from happening. Also added a test case for the `promise_type` case.