### PR TITLE
Add client_transparent attribute to String constructors

### DIFF
--- a/include/client/new/types.h
+++ b/include/client/new/types.h
@@ -625,7 +625,9 @@ namespace [[cheerp::genericjs]] client {
 		[[cheerp::interface_name(("fromCharCode"))]]
 		static _Any* _fromCharCode(_Args... data);
 	public:
+		[[cheerp::client_transparent]]
 		String(const String* x) noexcept;
+		[[cheerp::client_transparent]]
 		String(const String& x) noexcept;
 		String(long x) noexcept;
 		String(unsigned long x) noexcept;


### PR DESCRIPTION
Changed in ts2cpp: https://github.com/leaningtech/ts2cpp/commit/f9035aef6bd7f4a441b0b775a51ee1e97185c68a

See also: https://github.com/leaningtech/cheerp-compiler/pull/248