### PR TITLE
Split atomic tests in lowering and non lowering

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -257,9 +257,12 @@ addToTestListIfMatch(Test.genericjsOnly('unit/coroutines/cast-promise.cpp', [['-
 addToTestListIfMatch(Test.common('unit/exceptions/test1.cpp', [['-fexceptions']]))
 addToTestListIfMatch(Test.linearOnly('unit/exceptions/test2.cpp', [['-fexceptions']]))
 addToTestListIfMatch(Test.common('unit/types/funccasts.cpp', [['-cheerp-fix-wrong-func-casts']]))
-addToTestListIfMatch(Test.common('unit/threading/atomic1.cpp', [['-pthread']]))
-addToTestListIfMatch(Test.linearOnly('unit/threading/atomic2.cpp', [['-pthread']]))
-addToTestListIfMatch(Test.common('unit/threading/atomic3.cpp', [['-pthread']]))
+addToTestListIfMatch(Test.common('unit/threading/atomic_lowering1.cpp', [[]]))
+addToTestListIfMatch(Test.linearOnly('unit/threading/atomic_lowering2.cpp', [[]]))
+addToTestListIfMatch(Test.common('unit/threading/atomic_lowering3.cpp', [[]]))
+addToTestListIfMatch(Test.wasmOnly('unit/threading/atomic1.cpp', [['-pthread']]))
+addToTestListIfMatch(Test.wasmOnly('unit/threading/atomic2.cpp', [['-pthread']]))
+addToTestListIfMatch(Test.wasmOnly('unit/threading/atomic3.cpp', [['-pthread']]))
 
 selected_tests = sorted(list(test_list))
 

--- a/tests/unit/threading/atomic_lowering1.cpp
+++ b/tests/unit/threading/atomic_lowering1.cpp
@@ -1,0 +1,45 @@
+#include <tests.h>
+#include <atomic>
+
+struct structWithAtomicMember
+{
+	std::atomic<int> atomicValue;
+};
+
+struct normalStruct
+{
+	int value;
+};
+
+int main()
+{
+	std::atomic<int> val = 4205;
+	val.fetch_add(1391);
+	val.fetch_and(6234);
+	val.fetch_or(9196);
+	val.fetch_sub(4985);
+	val.fetch_xor(7578);
+	assertEqual(val.load(), 15641, "Atomic binary operations");
+
+	int b = 90;
+	b += val.exchange(3125);
+	b += val.fetch_add(7264);
+	b += val.fetch_sub(4981);
+	b += val.fetch_or(2037);
+	b += val.fetch_and(8185);
+	b += val.load();
+	assertEqual(b, 46915 , "Atomic binary return values");
+
+	structWithAtomicMember s1;
+	s1.atomicValue.store(3);
+	s1.atomicValue.fetch_add(95);
+	s1.atomicValue.fetch_and(51);
+	assertEqual(s1.atomicValue.load(), 34, "Atomic value inside struct");
+
+	normalStruct s2 = {3};
+	std::atomic<normalStruct> s3;
+	s3.store(s2);
+	s2.value = 25;
+	s2 = s3.load();
+	assertEqual(s2.value, 3, "Atomic struct");
+}

--- a/tests/unit/threading/atomic_lowering2.cpp
+++ b/tests/unit/threading/atomic_lowering2.cpp
@@ -1,0 +1,28 @@
+#include <tests.h>
+#include <atomic>
+
+struct Node
+{
+	int value;
+	Node* next;
+};
+std::atomic<Node*> listHead(nullptr);
+
+void appendToList(int newValue)
+{
+	Node* oldHead = listHead;
+	Node* newNode = new Node {newValue, oldHead};
+
+	while (!listHead.compare_exchange_strong(oldHead, newNode))
+		newNode->next = oldHead;
+}
+
+int main()
+{
+	for (int i = 0; i < 10; i++)
+		appendToList(i);
+
+	Node* it = listHead;
+	it = it->next->next->next;
+	assertEqual(it->value, 6, "Compare exchange list");
+}

--- a/tests/unit/threading/atomic_lowering3.cpp
+++ b/tests/unit/threading/atomic_lowering3.cpp
@@ -1,0 +1,19 @@
+#include <tests.h>
+#include <atomic>
+
+std::atomic<int> value(0);
+
+void addToNumber()
+{
+	int num = value.load();
+	int newNum = num + 1;
+	while (!value.compare_exchange_weak(num, newNum))
+		newNum = num + 1;
+}
+
+int main()
+{
+	for (int i = 0; i < 100; i++)
+		addToNumber();
+	assertEqual(value.load(), 100, "Simple compare exchange");
+}


### PR DESCRIPTION
We run the non lowered ones only for wasm, while we run the lowered ones for all targets. atomic_lowering2 is skipped for genericjs because std::atomic is currently unsafe.