### PR TITLE
Bump minimum CMake version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 3.10)
 project (Cheerp_Utils LANGUAGES)
 
 set (CHEERP_PREFIX ${CMAKE_INSTALL_PREFIX} CACHE FILEPATH "set cheerp installation prefix")


### PR DESCRIPTION
Compatibility with CMake version < 3.5 was removed in CMake 4, and versions < 3.10 are deprecated.