### PR TITLE
Use relative paths + CMAKE_CURRENT_LIST_DIR to find cheerp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,10 @@
 cmake_minimum_required (VERSION 3.10)
 project (Cheerp_Utils LANGUAGES)
 
-set (CHEERP_PREFIX ${CMAKE_INSTALL_PREFIX} CACHE FILEPATH "set cheerp installation prefix")
-execute_process(COMMAND "${CMAKE_INSTALL_PREFIX}/bin/clang" --version
+if(NOT DEFINED CHEERP_COMPILER)
+  set(CHEERP_COMPILER "${CMAKE_INSTALL_PREFIX}/bin/clang")
+endif()
+execute_process(COMMAND "${CHEERP_COMPILER}" --version
                 OUTPUT_VARIABLE CMAKE_CHEERP_RAW_VERSION)
 message(WARNING "Cheerp raw version string ${CMAKE_CHEERP_RAW_VERSION}")
 string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+"

--- a/scripts/cheerpwrap.in
+++ b/scripts/cheerpwrap.in
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export CHEERP_PREFIX=@CHEERP_PREFIX@
+export CHEERP_PREFIX=$(dirname "$0")/..
 export PATH=$CHEERP_PREFIX/libexec:$PATH
 exec $@
 EOF

--- a/tools/CheerpCommon.cmake.in
+++ b/tools/CheerpCommon.cmake.in
@@ -1,8 +1,10 @@
-list(APPEND CMAKE_MODULE_PATH "@CHEERP_PREFIX@/share/cmake/Modules")
+get_filename_component(CHEERP_PREFIX "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
+
+list(APPEND CMAKE_MODULE_PATH "${CHEERP_PREFIX}/share/cmake/Modules")
 # specify the cross compiler
-SET(CMAKE_C_COMPILER @CHEERP_PREFIX@/bin/clang CACHE FILEPATH "C Compiler")
-SET(CMAKE_CXX_COMPILER @CHEERP_PREFIX@/bin/clang++ CACHE FILEPATH "C++ Compiler")
-SET(CMAKE_LINKER @CHEERP_PREFIX@/bin/llvm-link CACHE FILEPATH "Linker")
+SET(CMAKE_C_COMPILER "${CHEERP_PREFIX}/bin/clang" CACHE FILEPATH "C Compiler")
+SET(CMAKE_CXX_COMPILER "${CHEERP_PREFIX}/bin/clang++" CACHE FILEPATH "C++ Compiler")
+SET(CMAKE_LINKER "${CHEERP_PREFIX}/bin/llvm-link" CACHE FILEPATH "Linker")
 
 # CMake compiler autodetection does not work with .bc, .wasm or .js files,
 # so we ask him to trust us that the compiler works and it is Clang
@@ -15,8 +17,8 @@ foreach(LANG in LISTS C CXX)
   set(CMAKE_${LANG}_COMPILER_FORCED FALSE)
 endforeach()
 
-# where is the target environment 
-SET(CMAKE_FIND_ROOT_PATH @CHEERP_PREFIX@)
+# where is the target environment
+SET(CMAKE_FIND_ROOT_PATH "${CHEERP_PREFIX}")
 
 # search for programs in the build host directories
 SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)


### PR DESCRIPTION
This allows the full cheerp toolchain to be placed in any directory post-installation.

Also add the optional CHEERP_COMPILER cmake variable to specify where to find clang during the build (it's used to get the version), which might not be in the same place where cheerp-utils is installed (e.g. nix).