### PR TITLE
cannot catch JSException in wasm functions

### DIFF
--- a/tests/unit/exceptions/exitexception1.cpp
+++ b/tests/unit/exceptions/exitexception1.cpp
@@ -9,8 +9,10 @@ int main()
 	{
 		if (i == 1)
 			exit(0);
+#ifndef __ASMJS__
 	} catch(cheerp::JSException& e) {
 		cheerp::console_log("JSException clause ignores exit-exception : FAILURE");
+#endif
 	} catch(...) {
 		cheerp::console_log("Catch-all clause ignores exit-exception : FAILURE");
 	}

--- a/tests/unit/exceptions/exitexception2.cpp
+++ b/tests/unit/exceptions/exitexception2.cpp
@@ -9,8 +9,10 @@ int main()
 	{
 		if (i == 1)
 			exit(1);
+#ifndef __ASMJS__
 	} catch(cheerp::JSException& e) {
 		cheerp::console_log("JSException clause ignores exit-exception : FAILURE");
+#endif
 	} catch(...) {
 		cheerp::console_log("Catch-all clause ignores exit-exception : FAILURE");
 	}


### PR DESCRIPTION
this comes up as an issue in the address spaces branch, but it was not supported all along